### PR TITLE
Add Dockerfile, allow generating NIP-05 config as well

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+FROM golang:1.19.4-alpine as builder
+
+# Force Go to use the cgo based DNS resolver. This is required to ensure DNS
+# queries required to connect to linked containers succeed.
+ENV GODEBUG netdns=cgo
+
+# Explicitly turn on the use of modules (until this becomes the default).
+ENV GO111MODULE on
+
+# Install dependencies.
+RUN apk add --no-cache --update alpine-sdk git make
+
+# Build and install binary.
+COPY . /go/src/github.com/hieblmi/go-host-lnaddr
+RUN cd /go/src/github.com/hieblmi/go-host-lnaddr && go install ./...
+
+# Start a new, final image to reduce size.
+FROM alpine as final
+
+# Expose port.
+EXPOSE 9990
+
+# Copy the binary from the builder image.
+COPY --from=builder /go/bin/go-host-lnaddr /bin/
+
+# Add bash.
+RUN apk add --no-cache \
+    bash \
+    ca-certificates
+
+RUN mkdir -p /app
+WORKDIR /app
+
+ENTRYPOINT ["go-host-lnaddr"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ go install github.com/hieblmi/go-host-lnaddr@latest
 - `SuccessMessage`: "Thank you!",
 - `InvoiceCallback`: "https://[YOUR_DOMAIN].com/invoice/" - this is the endpoint that will create the invoice
 - `AddressServerPort`: 9990 - the port your reverse proxy points to
+- `Nostr`: `{ "names": {...}, "relays": {...} }` - See https://github.com/nostr-protocol/nips/blob/master/05.md#example for details.
 - `Notificators`: [
         {
             "Type": "mail",

--- a/config.json
+++ b/config.json
@@ -24,6 +24,14 @@
 	"SuccessMessage": "Thank you!",
 	"InvoiceCallback": "https://allmysats.com/invoice/",
 	"AddressServerPort": 9990,
+	"Nostr": {
+		"names": {
+			"myNostrUsername": "npub1h....."
+		},
+		"relays": {
+			"b9b.....": ["wss://my.relay.com"]
+		}
+	},
 	"Notificators": [
 		{
 			"Type": "mail",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/hieblmi/go-host-lnaddr
 go 1.15
 
 require (
+	github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
+	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/tidwall/gjson v1.8.1
 	github.com/tidwall/sjson v1.1.7
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible h1:2cauKuaELYAEARXRkq2LrJ0yDDv1rW7+wrTEdVL3uaU=
+github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible/go.mod h1:qf9acutJ8cwBUhm1bqgz6Bei9/C/c93FPDljKWwsOgM=
+github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
+github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=
 github.com/tidwall/gjson v1.8.0/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
 github.com/tidwall/gjson v1.8.1 h1:8j5EE9Hrh3l9Od1OIEDAb7IpezNA20UdRngNAj5N0WU=
 github.com/tidwall/gjson v1.8.1/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=


### PR DESCRIPTION
This PR adds a Dockerfile (you can test out a build at `guggero/go-host-lnaddr`).

In order to get [NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md#example) style verification working on Nostr, this PR also adds an optional `Nostr` config item that renders to the `/.well-known/nostr.json` file.