### PR TITLE
Correct RPCHost port in config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
-	"RPCHost": "localhost:9735",
+	"RPCHost": "localhost:10009",
 	"InvoiceMacaroonPath": "/home/alice/.lnd/data/chain/bitcoin/mainnet/invoices.macaroon",
 	"TLSCertPath": "/home/alice/.lnd/tls.cert",
     "WorkingDir": "/home/alice/.go-host-lnaddr",,


### PR DESCRIPTION
Update the config.json file with the appropriate RPCHost port.
By default, lnd uses port 10009 for gRPC communication.