### PR TITLE
Remove unused DescriptionHash from LNUrlPay struct

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,6 @@ type LNUrlPay struct {
 	Tag             string `json:"tag"`
 	Metadata        string `json:"metadata"`
 	Callback        string `json:"callback"`
-	DescriptionHash []byte
 }
 
 type Invoice struct {


### PR DESCRIPTION
Remove the unused DescriptionHash from the LNUrlPay struct that is used
in HTTP responses to LNUrlp requests. The DescriptionHash belongs to the
InvoiceParams in invoice_manager.go