### PR TITLE
Small but important fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -325,13 +325,15 @@ func setupIndexHandler(config ServerConfig) {
 }
 
 func metadataToString(config ServerConfig) (string, error) {
-	thumbnailMetadata, err := thumbnailToMetadata(config.Thumbnail)
-	if err != nil {
-		return "", err
-	}
+	if config.Thumbnail != "" {
+		thumbnailMetadata, err := thumbnailToMetadata(config.Thumbnail)
+		if err != nil {
+			return "", err
+		}
 
-	if thumbnailMetadata != nil {
-		config.Metadata = append(config.Metadata, thumbnailMetadata)
+		if thumbnailMetadata != nil {
+			config.Metadata = append(config.Metadata, thumbnailMetadata)
+		}
 	}
 
 	marshalledMetadata, err := json.Marshal(config.Metadata)

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ type ServerConfig struct {
 	AddressServerPort   int               `json:"AddressServerPort" toml:"AddressServerPort"`
 	Nostr               *NostrConfig      `json:"Nostr" toml:"Nostr"`
 	Notifiers           []notifier.Config `json:"Notifiers" toml:"Notifiers"`
+	Notificators        []notifier.Config `json:"Notificators" toml:"Notificators"`
 	Zaps                *ZapsConfig       `json:"Zaps" toml:"Zaps"`
 }
 
@@ -148,6 +149,10 @@ func main() {
 
 	setupHandlerPerAddress(config)
 	setupNostrHandlers(config.Nostr)
+	if config.Notificators != nil && config.Notifiers == nil {
+		config.Notifiers = config.Notificators
+		log.Warn("The option Notificators has been renamed to Notifiers, please update your config as the old name will be deprecated soon")
+	}
 	notifier.SetupNotifiers(config.Notifiers, log)
 	setupIndexHandler(config)
 

--- a/notifier/mail_notif.go
+++ b/notifier/mail_notif.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/smtp"
+	"time"
 )
 
 type MailNotifier struct {
@@ -46,9 +47,10 @@ func (m *MailNotifier) Notify(amount uint64, comment string) (err error) {
 	if comment != "" {
 		comment = fmt.Sprintf("Sender said: \"%s\"", comment)
 	}
-	body := fmt.Sprintf("From: lnaddress payment\nSubject: %s\n\nYou've "+
+	body := fmt.Sprintf("Date: %s\nFrom: %s\nSubject: %s\n\nYou've "+
 		"received %d sats to your lightning address. %s",
-		m.From, amount, comment)
+		time.Now().Format(time.RFC1123Z), m.From, "lnaddress payment",
+		amount, comment)
 
 	err = smtp.SendMail(
 		m.Server, auth, m.From, []string{m.To}, []byte(body),


### PR DESCRIPTION
There are a few papercuts I've encountered, some were present before and some are from the recent refactors.

1. Add the `Date:` header to mail. Without it the mail's date is set to the moment it has been received by the mail client. When I check my mail on a work PC for example I get a few messages about LN payments as if they just happened while in fact they can be from a few days ago.
2. The `Thumbnail` config field should be optional, otherwise all metadata gets discarded with a file not found error.
3. Renaming config fields without fallback is generally a bad idea, things would stop working after update for no apparent reason. The old field named `Notificators` is no longer checked so the user would stop receiving messages after update until config is updated manually which is always a frustrating burden. Added a fallback with a deprecation warning.